### PR TITLE
Add baseURL config option

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "Apache-2.0",
   "homepage": "https://github.com/developit/redaxios",
   "devDependencies": {
+    "core-js": "^2.6.11",
     "eslint": "^6.8.0",
     "eslint-config-developit": "^1.1.1",
     "file-loader": "^5.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -64,22 +64,6 @@ export default (function create(defaults) {
 	}
 
 	/**
-	 * Creates a new URL by combining the baseURL with the URL
-	 * only when the URL is not already an absolute URL.
-	 * @private
-	 * @param {string} baseURL The base URL
-	 * @returns {string} The combined full path
-	 */
-	function buildFullUrl(baseURL, url) {
-		const isAbsoluteURL = /^([a-z][a-z\d+\-.]*:)?\/\//i.test(url);
-		if (baseURL && !isAbsoluteURL) {
-			return `${baseURL.replace(/\/+$/, '')}/${url.replace(/^\/+/, '')}`;
-		}
-
-		return url;
-	}
-
-	/**
 	 * @public
 	 * @type {((config?: Options) => Promise<Response>) | ((url: string, config?: Options) => Promise<Response>)}
 	 */
@@ -182,7 +166,7 @@ export default (function create(defaults) {
 		}
 
 		if (options.baseURL) {
-			url = buildFullUrl(options.baseURL, url);
+			url = new URL(url, options.baseURL);
 		}
 
 		/** @type {Response} */

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,22 @@ export default (function create(defaults) {
 	}
 
 	/**
+	 * Creates a new URL by combining the baseURL with the URL
+	 * only when the URL is not already an absolute URL.
+	 * @private
+	 * @param {string} baseURL The base URL
+	 * @returns {string} The combined full path
+	 */
+	function buildFullUrl(baseURL, url) {
+		const isAbsoluteURL = /^([a-z][a-z\d+\-.]*:)?\/\//i.test(url);
+		if (baseURL && !isAbsoluteURL) {
+			return `${baseURL.replace(/\/+$/, '')}/${url.replace(/^\/+/, '')}`;
+		}
+
+		return url;
+	}
+
+	/**
 	 * @public
 	 * @type {((config?: Options) => Promise<Response>) | ((url: string, config?: Options) => Promise<Response>)}
 	 */
@@ -162,6 +178,10 @@ export default (function create(defaults) {
 
 		if (options.auth) {
 			customHeaders.Authorization = options.auth;
+		}
+
+		if (options.baseURL) {
+			url = buildFullUrl(options.baseURL, url);
 		}
 
 		/** @type {Response} */

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -50,6 +50,27 @@ describe('redaxios', () => {
 		expect(res.data).toEqual({ hello: 'world' });
 	});
 
+	it('should make a request with a baseURL', async () => {
+		const oldFetch = window.fetch;
+		try {
+			window.fetch = jasmine.createSpy('fetch').and.returnValue(Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('') }));
+			const req = axios.get('/bar', {
+				baseURL: 'http://foo'
+			});
+			expect(window.fetch).toHaveBeenCalledTimes(1);
+			expect(window.fetch).toHaveBeenCalledWith('http://foo/bar', jasmine.objectContaining({
+				method: 'get',
+				headers: {},
+				body: undefined
+			}));
+			const res = await req;
+			expect(res.status).toEqual(200);
+		}
+		finally {
+			window.fetch = oldFetch;
+		}
+	});
+
 	it('should issue POST requests', async () => {
 		const oldFetch = window.fetch;
 		try {


### PR DESCRIPTION
Added the `baseURL` config option. This uses the same logic of adding combining the `baseURL` with the requested URL as axios.

Closes #12 