### PR TITLE
Change Content-Type to 'application/x-www-form-urlencoded' when formData

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,11 +142,14 @@ export default (function create(defaults) {
 				}
 			}
 		}
-		
+
 		const fetchFunc = options.fetch || fetch;
 		const customHeaders = {};
 
-		if (data && typeof data === 'object') {
+		if (data && data instanceof FormData) {
+			customHeaders['Content-Type'] = 'application/x-www-form-urlencoded';
+		}
+		else if (data && typeof data === 'object') {
 			data = JSON.stringify(data);
 			customHeaders['Content-Type'] = 'application/json';
 		}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,4 +83,19 @@ describe('redaxios', () => {
 		expect(res.status).toEqual(200);
 		expect(JSON.parse(res.data)).toEqual({ hello: 'world' });
 	});
+
+	it('should send formData as application/x-www-form-urlencoded', async() => {
+		window.fetch = jasmine.createSpy('fetch').and.returnValue(Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('yep') }));
+		const data = new FormData();
+		data.append('hello', 'world');
+		axios.post('/foo', data);
+		expect(window.fetch).toHaveBeenCalledTimes(1);
+		expect(window.fetch).toHaveBeenCalledWith('/foo', jasmine.objectContaining({
+			method: 'post',
+			headers: {
+				'content-type': 'application/x-www-form-urlencoded'
+			},
+			body: data
+		}));
+	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -85,17 +85,23 @@ describe('redaxios', () => {
 	});
 
 	it('should send formData as application/x-www-form-urlencoded', async() => {
-		window.fetch = jasmine.createSpy('fetch').and.returnValue(Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('yep') }));
-		const data = new FormData();
-		data.append('hello', 'world');
-		axios.post('/foo', data);
-		expect(window.fetch).toHaveBeenCalledTimes(1);
-		expect(window.fetch).toHaveBeenCalledWith('/foo', jasmine.objectContaining({
-			method: 'post',
-			headers: {
-				'content-type': 'application/x-www-form-urlencoded'
-			},
-			body: data
-		}));
+		const oldFetch = window.fetch;
+		try {
+			window.fetch = jasmine.createSpy('fetch').and.returnValue(Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('yep') }));
+			const data = new FormData();
+			data.append('hello', 'world');
+			axios.post('/foo', data);
+			expect(window.fetch).toHaveBeenCalledTimes(1);
+			expect(window.fetch).toHaveBeenCalledWith('/foo', jasmine.objectContaining({
+				method: 'post',
+				headers: {
+					'content-type': 'application/x-www-form-urlencoded'
+				},
+				body: data
+			}));
+		}
+		finally {
+			window.fetch = oldFetch;
+		}
 	});
 });


### PR DESCRIPTION
Per #28 when data is instance of FormData the content type header gets set to 'application/x-www-form-urlencoded'. 
Maybe it would be good to be able to customize the header just in case you want to send files and set it to 'multipart/form-data'.