### PR TITLE
"self" to not be a mandatory global variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -192,7 +192,7 @@ export default (function create(defaults) {
 		});
 	}
 
-	redaxios.CancelToken = self.AbortController || Object;
+	redaxios.CancelToken = typeof self === 'object' && self.AbortController || Object;
 
 	redaxios.create = create;
 


### PR DESCRIPTION
Currently in case we want to use `redaxios` within a nodejs process, we have to define `self` on the global. This PR eliminates this requirement.