### PR TITLE
fix stringifying form data as json

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ export default (function create(defaults) {
 		const fetchFunc = options.fetch || fetch;
 		const customHeaders = {};
 
-		if (data && typeof data === 'object') {
+		if (data && typeof data === 'object' && !(data instanceof FormData)) {
 			data = JSON.stringify(data);
 			customHeaders['Content-Type'] = 'application/json';
 		}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,6 +75,30 @@ describe('redaxios', () => {
 		}
 	});
 
+	it('should issue POST requests with FormData', async () => {
+		const oldFetch = window.fetch;
+		try {
+			window.fetch = jasmine.createSpy('fetch').and.returnValue(Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('yep') }));
+			const data = new FormData();
+			formData.append('hello', 'world');
+			const req = axios.post('/foo', formData, { headers: { 'content-type': 'multipart/form-data' } });
+			expect(window.fetch).toHaveBeenCalledTimes(1);
+			expect(window.fetch).toHaveBeenCalledWith('/foo', jasmine.objectContaining({
+				method: 'post',
+				headers: {
+					'content-type': 'multipart/form-data'
+				},
+				body: data
+			}));
+			const res = await req;
+			expect(res.status).toEqual(200);
+			expect(res.data).toEqual('yep');
+		}
+		finally {
+			window.fetch = oldFetch;
+		}
+	});
+	
 	it('should accept a custom fetch implementation', async () => {
 		const req = axios.get(jsonExample, { fetch });
 		expect(req).toBeInstanceOf(Promise);


### PR DESCRIPTION
FormData type is `object` which caused redaxios to transform it into a string before sending the request.
This made it not possible to send FormData at all through redaxios.