### PR TITLE
fix: Resolving bug with relative baseURLs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -178,7 +178,7 @@ export default (function create(/** @type {Options} */ defaults) {
 		}
 
 		if (options.baseURL) {
-			url = new URL(url, options.baseURL) + '';
+			url = options.baseURL + url;
 		}
 
 		if (options.params) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -98,6 +98,31 @@ describe('redaxios', () => {
 				window.fetch = oldFetch;
 			}
 		});
+
+		it('should resolve URLs with a relative baseURL', async () => {
+			const oldFetch = window.fetch;
+			try {
+				window.fetch = jasmine
+					.createSpy('fetch')
+					.and.returnValue(Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('') }));
+				const req = axios.get('/bar', {
+					baseURL: '/foo'
+				});
+				expect(window.fetch).toHaveBeenCalledTimes(1);
+				expect(window.fetch).toHaveBeenCalledWith(
+					'/foo/bar',
+					jasmine.objectContaining({
+						method: 'get',
+						headers: {},
+						body: undefined
+					})
+				);
+				const res = await req;
+				expect(res.status).toEqual(200);
+			} finally {
+				window.fetch = oldFetch;
+			}
+		});
 	});
 
 	describe('options.headers', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bugfix(?), perhaps feature expansion. 

**Did you add tests for your changes?**

Yes, a test was added to cover relative `baseURL`'s being used with Redaxios. Pretty much a copy/paste of the existing test but this time with a relative baseURL being used.

**Summary**

This PR fixes the issue I've outlined in #45. As it was, Redaxios constructed its URL, if a `baseURL` was provided, with `new URL('/bar', '/foo');`. However, `/foo` would not be a valid base URL and would cause an error if this was attempted. 

I fixed this with simple string concatenation. I'm not sure if there was a reason to use the URL constructor, so forgive me if I'm missing something, but string concatenation should do the trick, be ever so slightly smaller, and expand Redaxios' feature set to include relative baseURLs. 

**Does this PR introduce a breaking change?**

No breaking changes