### PR TITLE
Add support for request cancellation using AbortController

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redaxios",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -66,6 +66,11 @@
  */
 
 /**
+ * @typedef CancelToken
+ * @type {{ (executor: Function): AbortSignal; source(): { token: AbortSignal; cancel: () => void; }; }}
+ */
+
+/**
  * @typedef CancelTokenSourceMethod
  * @type {() => { token: AbortSignal, cancel: () => void }}
  */
@@ -160,7 +165,7 @@ export default (function create(/** @type {Options} */ defaults) {
 	}
 
 	/**
-	 * @public
+	 * @private
 	 * @type {CancelTokenSourceMethod}
 	 * @returns
 	 */
@@ -261,7 +266,7 @@ export default (function create(/** @type {Options} */ defaults) {
 
 	/**
 	 * @public
-	 * @type {Function}
+	 * @type {CancelToken}
 	 */
 	redaxios.CancelToken = CancelToken;
 

--- a/src/index.js
+++ b/src/index.js
@@ -153,11 +153,10 @@ export default (function create(/** @type {Options} */ defaults) {
 		}
 
 		const ac = new AbortController();
-		const { signal, abort } = ac;
 
-		executor(abort.bind(ac));
+		executor(ac.abort.bind(ac));
 
-		return signal;
+		return ac.signal;
 	}
 
 	/**
@@ -167,11 +166,10 @@ export default (function create(/** @type {Options} */ defaults) {
 	 */
 	CancelToken.source = () => {
 		const ac = new AbortController();
-		const { signal: token, abort } = ac;
 
 		return {
-			token,
-			cancel: abort.bind(ac)
+			token: ac.signal,
+			cancel: ac.abort.bind(ac)
 		};
 	};
 

--- a/src/index.js
+++ b/src/index.js
@@ -153,9 +153,11 @@ export default (function create(/** @type {Options} */ defaults) {
 		}
 
 		const ac = new AbortController();
-		executor(() => ac.abort());
+		const { signal, abort } = ac;
 
-		return ac.signal;
+		executor(abort.bind(ac));
+
+		return signal;
 	}
 
 	/**
@@ -165,10 +167,11 @@ export default (function create(/** @type {Options} */ defaults) {
 	 */
 	CancelToken.source = () => {
 		const ac = new AbortController();
+		const { signal: token, abort } = ac;
 
 		return {
-			token: ac.signal,
-			cancel: () => ac.abort()
+			token,
+			cancel: abort.bind(ac)
 		};
 	};
 

--- a/src/index.js
+++ b/src/index.js
@@ -272,6 +272,13 @@ export default (function create(/** @type {Options} */ defaults) {
 
 	/**
 	 * @public
+	 * @param {DOMError} e
+	 * @returns {boolean}
+	 */
+	redaxios.isCancel = (e) => e.name === 'AbortError';
+
+	/**
+	 * @public
 	 * @type {Options}
 	 */
 	redaxios.defaults = defaults;

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@
  * @property {Array<(body: any, headers: Headers) => any?>} [transformRequest] An array of transformations to apply to the outgoing request
  * @property {string} [baseURL] a base URL from which to resolve all URLs
  * @property {typeof window.fetch} [fetch] Custom window.fetch implementation
+ * @property {AbortSignal} [signal] Signal returned by AbortController
  * @property {any} [data]
  */
 
@@ -195,7 +196,8 @@ export default (function create(/** @type {Options} */ defaults) {
 			method: _method || options.method,
 			body: data,
 			headers: deepMerge(options.headers, customHeaders, true),
-			credentials: options.withCredentials ? 'include' : undefined
+			credentials: options.withCredentials ? 'include' : undefined,
+			signal: options.signal
 		}).then((res) => {
 			for (const i in res) {
 				if (typeof res[i] != 'function') response[i] = res[i];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -273,4 +273,23 @@ describe('redaxios', () => {
 			expect(fetchMock).toHaveBeenCalledWith('/foo?e=iamthelaw', jasmine.any(Object));
 		});
 	});
+
+	describe('options.signal', () => {
+		it('should cancel a request when signal is passed', async () => {
+			const cancelToken = new axios.CancelToken();
+
+			const axiosGet = axios.get(jsonExample, {
+				signal: cancelToken.signal
+			});
+			cancelToken.abort();
+
+			const spy = jasmine.createSpy();
+			await axiosGet.catch(spy);
+
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(spy).toHaveBeenCalledWith(
+				jasmine.objectContaining({ code: 20, message: 'The user aborted a request.', name: 'AbortError' })
+			);
+		});
+	});
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -306,8 +306,10 @@ describe('redaxios', () => {
 			cancel();
 
 			const spy = jasmine.createSpy();
-			await axiosGet.catch(spy);
+			let error;
+			await axiosGet.catch((e) => ((error = e), spy(e)));
 
+			expect(axios.isCancel(error)).toBeTruthy(true);
 			expect(spy).toHaveBeenCalledTimes(1);
 			expect(spy).toHaveBeenCalledWith(
 				jasmine.objectContaining({ code: 20, message: 'The user aborted a request.', name: 'AbortError' })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -274,7 +274,7 @@ describe('redaxios', () => {
 		});
 	});
 
-	describe('options.signal', () => {
+	describe('Request cancellation using options.cancelToken', () => {
 		it('should cancel a request when cancelToken is passed as source.token', async () => {
 			const CancelToken = axios.CancelToken;
 			const source = CancelToken.source();


### PR DESCRIPTION
As per #11 added support for request cancellation using the abort controller exposed as CancelToken.

Added test for the same.

@developit I don't know if this the correct way to do this, please let me know what to if I'm wrong