### PR TITLE
fix: default credentials to same-origin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@ export default (function create(/** @type {Options} */ defaults) {
 			method: _method || options.method,
 			body: data,
 			headers: deepMerge(options.headers, customHeaders, true),
-			credentials: options.withCredentials ? 'include' : undefined
+			credentials: options.withCredentials ? 'include' : 'same-origin'
 		}).then((res) => {
 			for (const i in res) {
 				if (typeof res[i] != 'function') response[i] = res[i];


### PR DESCRIPTION
Even though based on [docs](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) it's default for most browsers, some browsers don't pass `same-origin` as default and not sending same origin cookies in fetch requests. The fix passes `same-origin` by default explicitly in `fetch`.

References:
- https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API
- https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials

![image](https://user-images.githubusercontent.com/5961873/91687334-1b51b380-eb7d-11ea-82b7-9fc7e955410a.png)

---

![image](https://user-images.githubusercontent.com/5961873/91580681-13222a00-e96b-11ea-822b-b2ff0f62681b.png)

