### PR TITLE
fix: added check for document, so redaxios will not break in Node

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,8 @@ export default (function create(/** @type {Options} */ defaults) {
 			customHeaders['content-type'] = 'application/json';
 		}
 
-		const m = typeof document !== 'undefined' && document.cookie.match(RegExp('(^|; )' + options.xsrfCookieName + '=([^;]*)'));
+		const m =
+			typeof document !== 'undefined' && document.cookie.match(RegExp('(^|; )' + options.xsrfCookieName + '=([^;]*)'));
 		if (m) customHeaders[options.xsrfHeaderName] = m[2];
 
 		if (options.auth) {

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ export default (function create(/** @type {Options} */ defaults) {
 			customHeaders['content-type'] = 'application/json';
 		}
 
-		const m = document.cookie.match(RegExp('(^|; )' + options.xsrfCookieName + '=([^;]*)'));
+		const m = typeof document !== 'undefined' && document.cookie.match(RegExp('(^|; )' + options.xsrfCookieName + '=([^;]*)'));
 		if (m) customHeaders[options.xsrfHeaderName] = m[2];
 
 		if (options.auth) {


### PR DESCRIPTION
Hi! 
I'm currently using redaxios in a project with Next.js and found this problem: using redaxios in Node.js leads to ReferenceError because there is no document object in Node. 

Axios for this case provides noop functions for non-browser environments: https://github.com/axios/axios/blob/04d45f20911a02e9457db9e9d104aa156e170b11/lib/helpers/cookies.js#L45.

I added a check on the document object so that code with redaxios can be used in the Node.js environment too

@developit, can you review, please?
