### PR TITLE
fix(types): return redaxios from create

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,12 @@
  * @type {<T=any>(url: string, body?: any, config?: Options) => Promise<Response<T>>}
  */
 
-/** */
-export default (function create(/** @type {Options} */ defaults) {
+/**
+ * @public
+ * @param {Options} defaults
+ * @returns {redaxios}
+ */
+function create(defaults) {
 	defaults = defaults || {};
 
 	/**
@@ -241,4 +245,7 @@ export default (function create(/** @type {Options} */ defaults) {
 	redaxios.create = create;
 
 	return redaxios;
-})();
+};
+
+// @ts-ignore TS2554
+export default create();


### PR DESCRIPTION
Currently the type generated for create is

```typescript
    /**
     * @public
     */
    create: (defaults?: Options) => any;
```

Specifying the return type makes it


```typescript
    /**
     * @public
     */
    create: typeof create;
```

and the new `create` type's return is the same as `_default`, but is unfortunately duplicated.