### PR TITLE
Don't override content-type for blobs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ export default (function create(/** @type {Options} */ defaults) {
 			data = f(data, options.headers) || data;
 		});
 
-		if (data && typeof data === 'object' && typeof data.append !== 'function') {
+		if (data && typeof data === 'object' && typeof data.append !== 'function' && !(data instanceof Blob)) {
 			data = JSON.stringify(data);
 			customHeaders['content-type'] = 'application/json';
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ export default (function create(/** @type {Options} */ defaults) {
 			data = f(data, options.headers) || data;
 		});
 
-		if (data && typeof data === 'object' && /^\[object (FormData|Blob)\]$/.test(data)) {
+		if (data && typeof data === 'object' && !/^\[object (FormData|Blob)\]$/.test(data)) {
 			data = JSON.stringify(data);
 			customHeaders['content-type'] = 'application/json';
 		}

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ export default (function create(/** @type {Options} */ defaults) {
 			data = f(data, options.headers) || data;
 		});
 
-		if (data && typeof data === 'object' && typeof data.append !== 'function' && !(data instanceof Blob)) {
+		if (data && typeof data === 'object' && /^\[object (FormData|Blob)\]$/.test(data)) {
 			data = JSON.stringify(data);
 			customHeaders['content-type'] = 'application/json';
 		}


### PR DESCRIPTION
This PR fixes an issue where a File body would have its content type overridden with `application/json`.