### PR TITLE
Convert verb to uppercase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,7 +196,7 @@ export default (function create(/** @type {Options} */ defaults) {
 		const fetchFunc = options.fetch || fetch;
 
 		return fetchFunc(url, {
-			method: _method || options.method,
+			method: (_method || options.method || 'get').toUpperCase(),
 			body: data,
 			headers: deepMerge(options.headers, customHeaders, true),
 			credentials: options.withCredentials ? 'include' : 'same-origin'

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -87,7 +87,7 @@ describe('redaxios', () => {
 				expect(window.fetch).toHaveBeenCalledWith(
 					'http://foo/bar',
 					jasmine.objectContaining({
-						method: 'get',
+						method: 'GET',
 						headers: {},
 						body: undefined
 					})
@@ -112,7 +112,7 @@ describe('redaxios', () => {
 				expect(window.fetch).toHaveBeenCalledWith(
 					'/foo/bar',
 					jasmine.objectContaining({
-						method: 'get',
+						method: 'GET',
 						headers: {},
 						body: undefined
 					})
@@ -203,7 +203,7 @@ describe('redaxios', () => {
 			expect(fetchMock).toHaveBeenCalledWith(
 				'/foo',
 				jasmine.objectContaining({
-					method: 'post',
+					method: 'POST',
 					headers: {
 						'content-type': 'application/json'
 					},
@@ -235,7 +235,7 @@ describe('redaxios', () => {
 				expect(fetchMock).toHaveBeenCalledWith(
 					'/foo',
 					jasmine.objectContaining({
-						method: 'post',
+						method: 'POST',
 						headers: {
 							'content-type': 'multipart/form-data'
 						},


### PR DESCRIPTION
In Google Chrome, `patch` specifically seems to be causing problems. I'd been Googling for about an hour and finally came across this SO post: https://stackoverflow.com/a/67744766/51021

Apparently, some verbs (`PATCH` in my case) ARE case-sensitive when comparing against a pre-flight `OPTIONS` check.

I think in order to be the most compatible with the `axios` module, and to make `PATCH` work during cross-origin requests, these verbs should be made uppercase (See `axios` source: [axios/lib/adapters/xhr.js#L32](https://github.com/axios/axios/blob/5ad6994/lib/adapters/xhr.js#L32))