### PR TITLE
Safeguard document.cookie for sandboxed applications

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,8 +173,13 @@ export default (function create(/** @type {Options} */ defaults) {
 			customHeaders['content-type'] = 'application/json';
 		}
 
-		const m =
-			typeof document !== 'undefined' && document.cookie.match(RegExp('(^|; )' + options.xsrfCookieName + '=([^;]*)'));
+		let m;
+
+		try {
+			m =
+				typeof document !== 'undefined' &&
+				document.cookie.match(RegExp('(^|; )' + options.xsrfCookieName + '=([^;]*)'));
+		} catch (e) {}
 		if (m) customHeaders[options.xsrfHeaderName] = decodeURIComponent(m[2]);
 
 		if (options.auth) {


### PR DESCRIPTION
In sandbox mode (iframes) even trying to read from document.cookie will throw an error.
![Screenshot 2022-03-29 at 14 12 21](https://user-images.githubusercontent.com/2965242/160608527-30f4205f-fcdf-4876-9184-b52067d15c93.png)
Therefore I've wrapped the document.cookie reading in a try/catch block.