### PR TITLE
Updated the size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # redaxios
 
-[Axios] has a great API that developers love. Redaxios provides that API in **800 bytes**, using native `fetch()`.
+[Axios] has a great API that developers love. Redaxios provides that API in **1600 bytes**, using native `fetch()`.
 
 For those searching for ways to shave a few kilobytes off of their bundles, that's less than 1/5th of the size. This is made possible by using the browser's native [Fetch API][fetch], which is [supported in all modern browsers](https://caniuse.com/#feat=fetch) and polyfilled by most tools including Next.js, Create React App and Preact CLI.
 


### PR DESCRIPTION
Redaxios is no longer 800 bytes, it's in fact double the size even when min+gzip. You can see it here:

https://unpkg.com/redaxios@0.4.1/dist/redaxios.js

<img width="169" alt="image" src="https://user-images.githubusercontent.com/2801252/165969690-bae8b0c2-d183-4704-aeef-999a95a4a3d6.png">
