### PR TITLE
Wrap rejected response, to stay in line with Axios API

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -219,7 +219,7 @@ function create(defaults) {
 				.catch(Object)
 				.then(() => {
 					const ok = options.validateStatus ? options.validateStatus(res.status) : res.ok;
-					return ok ? response : Promise.reject(response);
+					return ok ? response : Promise.reject({ response });
 				});
 		});
 	}


### PR DESCRIPTION
Axios returns a custom object when request status is not OK (https://github.com/axios/axios/#handling-errors):

```js
axios.get('/user/12345')
  .catch(function (error) {
    if (error.response) {
      console.log(error.response.data);
      console.log(error.response.status);
      console.log(error.response.headers);
    }
    // ...
  })
```

Redaxios on the other hand throws the response directly, as pointed out in comment https://github.com/developit/redaxios/issues/48#issuecomment-958745702.

The easiest fix would be just to wrap the response in an object, but for better compatibility we could add [some other fields](https://github.com/axios/axios/blob/892c241773e7dda78a969ac1faa9b365e24f6cc8/lib/core/AxiosError.js#L8-L12).