### PR TITLE
chore: add dependabot to the project to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "npm deps"
+      include: "scope"


### PR DESCRIPTION
Hi, i really like the project, i discovered it just weeks ago and wanted to add this small contribution to keep dependencies (dev since they are the only one) always up to date weekly.